### PR TITLE
fix tests

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                static-api-generator
-version:             0.3.0.1
+version:             0.3.0.2
 github:              jgalat/static-api-generator
 license:             GPL
 author:              Jorge Galat <jrgglt@gmail.com>

--- a/test/Network/API/StaticAPISpec.hs
+++ b/test/Network/API/StaticAPISpec.hs
@@ -17,7 +17,6 @@ default (Text)
 main :: IO ()
 main = hspec spec
 
-withStaticAPI :: StaticAPI () -> SpecWith ((), Application) -> Spec
 withStaticAPI api =
     with (staticAPI api >> return (staticApp (defaultFileServerSettings "public"))) .
         after_ (removeDirectoryRecursive "public")


### PR DESCRIPTION
Depending on the version of hspec-wai `with` signature uses
a SpecWith Application or SpecWith ((), Application).
Removing the signature solves the problem.